### PR TITLE
Hotfix/5.1.12

### DIFF
--- a/src/abstractions/Backend.Fx/Environment/Persistence/IDatabaseUtil.cs
+++ b/src/abstractions/Backend.Fx/Environment/Persistence/IDatabaseUtil.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Backend.Fx.Environment.Persistence
 {
     public interface IDatabaseUtil
     {
         bool WaitUntilAvailable(int retries, Func<int, TimeSpan> sleepDurationProvider);
+        Task<bool> WaitUntilAvailableAsync(int retries, Func<int, TimeSpan> sleepDurationProvider, CancellationToken cancellationToken = default);
     }
 }

--- a/src/abstractions/Backend.Fx/Patterns/DependencyInjection/BackendFxDbApplication.cs
+++ b/src/abstractions/Backend.Fx/Patterns/DependencyInjection/BackendFxDbApplication.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Backend.Fx.Environment.MultiTenancy;
 using Backend.Fx.Environment.Persistence;
 using Backend.Fx.Logging;
@@ -29,21 +30,24 @@ namespace Backend.Fx.Patterns.DependencyInjection
         /// </summary>
         public IDatabaseBootstrapper DatabaseBootstrapper { get; }
 
-        protected sealed override async Task OnBoot()
+        protected sealed override async Task OnBoot(CancellationToken cancellationToken)
         {
-            await OnDatabaseBoot();
-            WaitForDatabase();
+            await OnDatabaseBoot(cancellationToken);
+            await WaitForDatabase(cancellationToken);
             DatabaseBootstrapper.EnsureDatabaseExistence();
-            await OnDatabaseBooted();
+            await OnDatabaseBooted(cancellationToken);
         }
 
-        protected virtual void WaitForDatabase() { }
+        protected virtual async Task WaitForDatabase(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+        }
 
         /// <summary>
         /// Extension point to do additional initialization before existence of database is ensured
         /// </summary>
         /// <returns></returns>
-        protected virtual async Task OnDatabaseBoot()
+        protected virtual async Task OnDatabaseBoot(CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
         }
@@ -52,7 +56,7 @@ namespace Backend.Fx.Patterns.DependencyInjection
         /// Extension point to do additional initialization after existence of database is ensured
         /// </summary>
         /// <returns></returns>
-        protected virtual async Task OnDatabaseBooted()
+        protected virtual async Task OnDatabaseBooted(CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
         }

--- a/src/abstractions/Backend.Fx/Patterns/DependencyInjection/IBackendFxApplication.cs
+++ b/src/abstractions/Backend.Fx/Patterns/DependencyInjection/IBackendFxApplication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Principal;
+using System.Threading;
 using System.Threading.Tasks;
 using Backend.Fx.Environment.MultiTenancy;
 using Backend.Fx.Logging;
@@ -25,26 +26,21 @@ namespace Backend.Fx.Patterns.DependencyInjection
         ITenantIdService TenantIdService { get; }
 
         /// <summary>
-        /// allows asynchronously awaiting application startup
-        /// </summary>
-        Task<bool> WaitForBootAsync(int timeoutMilliSeconds = int.MaxValue);
-
-        /// <summary>
         /// allows synchronously awaiting application startup
         /// </summary>
-        bool WaitForBoot(int timeoutMilliSeconds = int.MaxValue);
+        bool WaitForBoot(int timeoutMilliSeconds = int.MaxValue, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Initializes ans starts the application (async)
         /// </summary>
         /// <returns></returns>
-        Task Boot();
+        Task Boot(CancellationToken cancellationToken = default);
 
         IDisposable BeginScope(IIdentity identity = null, TenantId tenantId = null);
 
         void Invoke(Action action, IIdentity identity, TenantId tenantId);
 
-        Task InvokeAsync(Action action, IIdentity identity, TenantId tenantId);
+        Task InvokeAsync(Action action, IIdentity identity, TenantId tenantId, CancellationToken cancellationToken = default);
 
         void Run<TJob>() where TJob : class, IJob;
 

--- a/src/abstractions/Backend.Fx/Patterns/UnitOfWork/IUnitOfWork.cs
+++ b/src/abstractions/Backend.Fx/Patterns/UnitOfWork/IUnitOfWork.cs
@@ -64,8 +64,6 @@
             _isCompleted = true;
         }
 
-        
-
         protected abstract void UpdateTrackingProperties(string userId, DateTime utcNow);
         protected abstract void Commit();
         protected abstract void Rollback();
@@ -76,7 +74,7 @@
             {
                 if (_isCompleted == false)
                 {
-                    Logger.Info($"Canceling unit of work #{_instanceId} because the instance is being disposed although it did not complete before. This should only occur during cleanup after errors.");
+                    Logger.Info($"Canceling unit of work #{_instanceId}.");
                     Rollback();
                 }
                 _lifetimeLogger?.Dispose();

--- a/src/abstractions/Backend.Fx/Patterns/UnitOfWork/ReadonlyDecorator.cs
+++ b/src/abstractions/Backend.Fx/Patterns/UnitOfWork/ReadonlyDecorator.cs
@@ -24,7 +24,7 @@ namespace Backend.Fx.Patterns.UnitOfWork
 
         public void Complete()
         {
-            //skip
+            // prevent completion, results in rollback on disposal
         }
 
         public ICurrentTHolder<IIdentity> IdentityHolder => _unitOfWorkImplementation.IdentityHolder;

--- a/src/environments/Backend.Fx.AspNetCore.Mvc/UnitOfWork/UnitOfWorkFilter.cs
+++ b/src/environments/Backend.Fx.AspNetCore.Mvc/UnitOfWork/UnitOfWorkFilter.cs
@@ -1,0 +1,40 @@
+﻿using Backend.Fx.Patterns.DependencyInjection;
+using Backend.Fx.Patterns.UnitOfWork;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Backend.Fx.AspNetCore.Mvc.UnitOfWork
+{
+    public class UnitOfWorkFilter : IActionFilter
+    {
+        private readonly IBackendFxApplication _application;
+
+        public UnitOfWorkFilter(IBackendFxApplication application)
+        {
+            _application = application;
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var unitOfWork = _application.CompositionRoot.GetInstance<IUnitOfWork>();
+            if (context.HttpContext.Request.IsSafe())
+            {
+                unitOfWork = new ReadonlyDecorator(unitOfWork);
+            }
+            unitOfWork.Begin();
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            var unitOfWork = _application.CompositionRoot.GetInstance<IUnitOfWork>();
+
+            try
+            {
+                unitOfWork.Complete();
+            }
+            finally
+            {
+                unitOfWork.Dispose();
+            }
+        }
+    }
+}

--- a/src/environments/Backend.Fx.AspNetCore/Bootstrapping/WaitForBootMiddleware.cs
+++ b/src/environments/Backend.Fx.AspNetCore/Bootstrapping/WaitForBootMiddleware.cs
@@ -28,7 +28,7 @@ namespace Backend.Fx.AspNetCore.Bootstrapping
         [UsedImplicitly]
         public async Task Invoke(HttpContext context)
         {
-            while (!await _application.WaitForBootAsync(3000))
+            while (!_application.WaitForBoot(3000))
             {
                 Logger.Info("Queuing Request while application is booting...");
             }

--- a/src/implementations/Backend.Fx.SimpleInjetorDependencyInjection/Modules/InfrastructureModule.cs
+++ b/src/implementations/Backend.Fx.SimpleInjetorDependencyInjection/Modules/InfrastructureModule.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Reflection;
 using System.Security.Principal;
 using Backend.Fx.Environment.Authentication;
 using Backend.Fx.Environment.MultiTenancy;
 using Backend.Fx.Logging;
+using Backend.Fx.Patterns.DataGeneration;
 using Backend.Fx.Patterns.DependencyInjection;
 using Backend.Fx.Patterns.EventAggregation.Domain;
 using Backend.Fx.Patterns.EventAggregation.Integration;
@@ -42,12 +44,16 @@ namespace Backend.Fx.SimpleInjectorDependencyInjection.Modules
             Logger.Debug($"Registering {nameof(CurrentTenantIdHolder)} as {nameof(ICurrentTHolder<TenantId>)}");
             container.Register<ICurrentTHolder<TenantId>, CurrentTenantIdHolder>();
 
+            // domain event subsystem
             Logger.Debug("Registering event aggregator");
             container.Register<IDomainEventAggregator>(_domainEventAggregatorFactory);
 
             // integration event subsystem
             Logger.Debug("Registering event bus");
             container.RegisterInstance(_eventBus);
+
+            // initial data generators collection (using the current assembly causes an empty collection)
+            container.Collection.Register<IDataGenerator>(typeof(InfrastructureModule).GetTypeInfo().Assembly);
 
             container.Register<IEventBusScope, EventBusScope>();
 

--- a/src/implementations/Backend.Fx.SqlServer/MsSqlServerUtil.cs
+++ b/src/implementations/Backend.Fx.SqlServer/MsSqlServerUtil.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
 using Backend.Fx.Environment.Persistence;
 using Backend.Fx.Logging;
 using Polly;
@@ -96,6 +98,40 @@ namespace Backend.Fx.SqlServer
                             var command = connection.CreateCommand();
                             command.CommandText = "SELECT count(*) FROM sys.databases WHERE Name = 'master'";
                             command.ExecuteScalar();
+                            return true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Info(ex, "No MSSQL instance was found");
+                        return false;
+                    }
+                });
+        }
+
+        public async Task<bool> WaitUntilAvailableAsync(int retries, Func<int, TimeSpan> sleepDurationProvider, CancellationToken cancellationToken = default)
+        {
+            Logger.Info($"Probing for SQL instance with {retries} retries.");
+            SqlConnectionStringBuilder sb = new SqlConnectionStringBuilder(ConnectionString) { InitialCatalog = "master" };
+            return await Policy
+                .HandleResult<bool>(result => result == false)
+                .WaitAndRetryAsync(retries, sleepDurationProvider)
+                .ExecuteAsync(async () =>
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        Logger.Info("Waiting until database is available was cancelled");
+                        return false;
+                    }
+
+                    try
+                    {
+                        using (var connection = new SqlConnection(sb.ConnectionString))
+                        {
+                            connection.Open();
+                            var command = connection.CreateCommand();
+                            command.CommandText = "SELECT count(*) FROM sys.databases WHERE Name = 'master'";
+                            await command.ExecuteScalarAsync(cancellationToken);
                             return true;
                         }
                     }

--- a/tests/Backend.Fx.SimpleInjectorDependencyInjection.Tests/DummyImpl/Bootstrapping/AnApplication.cs
+++ b/tests/Backend.Fx.SimpleInjectorDependencyInjection.Tests/DummyImpl/Bootstrapping/AnApplication.cs
@@ -65,7 +65,7 @@ namespace Backend.Fx.SimpleInjectorDependencyInjection.Tests.DummyImpl.Bootstrap
 
         public TenantId DemoTenantId { get; private set; }
 
-        protected override Task OnBooted()
+        protected override Task OnBooted(CancellationToken cancellationToken)
         {
             var tenantService = new TenantService(CompositionRoot.GetInstance<IEventBus>(), _tenantRepository);
             this.RegisterSeedActionForNewlyCreatedTenants(tenantService);

--- a/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheEventBus.cs
+++ b/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheEventBus.cs
@@ -27,7 +27,7 @@ namespace Backend.Fx.Tests.Patterns.EventAggregation.Integration
             sw.Start();
             var integrationEvent = new TestIntegrationEvent(1,"a");
             await Sut.Publish(integrationEvent);
-            Assert.True(sw.ElapsedMilliseconds < 100);
+            Assert.True(sw.ElapsedMilliseconds < 900);
             integrationEvent.Processed.Wait(Debugger.IsAttached ? int.MaxValue : 10000);
             Assert.True(sw.ElapsedMilliseconds > 1000);
         }
@@ -116,7 +116,7 @@ namespace Backend.Fx.Tests.Patterns.EventAggregation.Integration
             Sut.Subscribe<DynamicEventHandler>(typeof(TestIntegrationEvent).FullName);
             Sut.Subscribe<TypedEventHandler, TestIntegrationEvent>();
             var integrationEvent = new TestIntegrationEvent(34, "gaga");
-            Task.Run(()=> Sut.Publish(integrationEvent)).Wait();
+            await Sut.Publish(integrationEvent);
             integrationEvent.Processed.Wait(Debugger.IsAttached ? int.MaxValue : 10000);
 
             A.CallTo(() => _app.TypedHandler.Handle(A<TestIntegrationEvent>


### PR DESCRIPTION
misleading error message on readonly unit of work disposal fixed 
empty collection of IDataGenerators ensured
async invoke fixed
unit of work filter implemented
host ctrl+c cancellation token available througout BackendFxApplication