### PR TITLE
#96 using ChangeTracker.StateChanged for aggregate modification tracking

### DIFF
--- a/src/abstractions/Backend.Fx/Patterns/UnitOfWork/IUnitOfWork.cs
+++ b/src/abstractions/Backend.Fx/Patterns/UnitOfWork/IUnitOfWork.cs
@@ -24,7 +24,6 @@
         private static readonly ILogger Logger = LogManager.Create<UnitOfWork>();
         private static int _index;
         private readonly int _instanceId = _index++;
-        private readonly IClock _clock;
         private readonly IDomainEventAggregator _eventAggregator;
         private readonly IEventBusScope _eventBusScope;
         private bool? _isCompleted;
@@ -33,18 +32,18 @@
         protected UnitOfWork(IClock clock, ICurrentTHolder<IIdentity> identityHolder,
                              IDomainEventAggregator eventAggregator, IEventBusScope eventBusScope)
         {
-            _clock = clock;
+            Clock = clock;
             _eventAggregator = eventAggregator;
             _eventBusScope = eventBusScope;
             IdentityHolder = identityHolder;
         }
 
         public ICurrentTHolder<IIdentity> IdentityHolder { get; }
+        public IClock Clock { get; }
 
         public virtual void Flush()
         {
             Logger.Debug("Flushing unit of work #" + _instanceId);
-            UpdateTrackingProperties(IdentityHolder.Current.Name, _clock.UtcNow);
         }
     
         public virtual void Begin()
@@ -62,8 +61,6 @@
             AsyncHelper.RunSync(()=>_eventBusScope.RaiseEvents());
             _isCompleted = true;
         }
-
-        protected abstract void UpdateTrackingProperties(string userId, DateTime utcNow);
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/implementations/Backend.Fx.EfCorePersistence/DbContextExtensions.cs
+++ b/src/implementations/Backend.Fx.EfCorePersistence/DbContextExtensions.cs
@@ -126,6 +126,7 @@ namespace Backend.Fx.EfCorePersistence
             }
         }
 
+        [Obsolete]
         public static void UpdateTrackingProperties(this DbContext dbContext, string userId, DateTime utcNow)
         {
             userId ??= "anonymous";

--- a/src/implementations/Backend.Fx.InMemoryPersistence/InMemoryUnitOfWork.cs
+++ b/src/implementations/Backend.Fx.InMemoryPersistence/InMemoryUnitOfWork.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security.Principal;
+﻿using System.Security.Principal;
 using Backend.Fx.Environment.DateAndTime;
 using Backend.Fx.Patterns.DependencyInjection;
 using Backend.Fx.Patterns.EventAggregation.Domain;
@@ -15,9 +14,6 @@ namespace Backend.Fx.InMemoryPersistence
         public InMemoryUnitOfWork(IClock clock, ICurrentTHolder<IIdentity> identityHolder, 
                                   IDomainEventAggregator eventAggregator, IEventBusScope eventBusScope) 
                 : base(clock, identityHolder, eventAggregator, eventBusScope)
-        { }
-
-        protected override void UpdateTrackingProperties(string userId, DateTime utcNow)
         { }
 
         public override void Complete()

--- a/tests/Backend.Fx.EfCorePersistence.Tests/TheDbContext.cs
+++ b/tests/Backend.Fx.EfCorePersistence.Tests/TheDbContext.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Backend.Fx.EfCorePersistence.Tests.DummyImpl.Domain;
 using Backend.Fx.EfCorePersistence.Tests.DummyImpl.Persistence;
@@ -34,7 +33,6 @@ namespace Backend.Fx.EfCorePersistence.Tests
                     blog.Posts.Add(new Post(4, blog, "new name 4"));
                     blog.Posts.Add(new Post(5, blog, "new name 5"));
                     dbContext.Add(blog);
-                    dbContext.UpdateTrackingProperties("me", DateTime.Now);
                     dbContext.SaveChanges();
                 }
 
@@ -48,7 +46,6 @@ namespace Backend.Fx.EfCorePersistence.Tests
                     blog.Posts.Add(new Post(8, blog, "new name 8"));
                     blog.Posts.Add(new Post(9, blog, "new name 9"));
                     blog.Posts.Add(new Post(10, blog, "new name 10"));
-                    dbContext.UpdateTrackingProperties("me", DateTime.Now);
                     dbContext.SaveChanges();
                 }
 

--- a/tests/Backend.Fx.Tests/Patterns/UnitOfWork/TestUnitOfWork.cs
+++ b/tests/Backend.Fx.Tests/Patterns/UnitOfWork/TestUnitOfWork.cs
@@ -11,12 +11,7 @@
     public class TestUnitOfWork : UnitOfWork
     {
         public int RollbackCount { get; private set; }
-        public int UpdateTrackingPropertiesCount { get; private set; }
         public int CommitCount { get; private set; }
-        protected override void UpdateTrackingProperties(string userId, DateTime utcNow)
-        {
-            UpdateTrackingPropertiesCount++;
-        }
 
         public override void Complete()
         {

--- a/tests/Backend.Fx.Tests/Patterns/UnitOfWork/TheUnitOfWork.cs
+++ b/tests/Backend.Fx.Tests/Patterns/UnitOfWork/TheUnitOfWork.cs
@@ -50,14 +50,5 @@ namespace Backend.Fx.Tests.Patterns.UnitOfWork
             sut.Dispose();
             A.CallTo(() => _eventBusScope.RaiseEvents()).MustNotHaveHappened();
         }
-
-        [Fact]
-        public void UpdatesTrackingPropertiesOnFlush()
-        {
-            TestUnitOfWork sut = new TestUnitOfWork(new FrozenClock(), CurrentIdentityHolder.CreateSystem(), _eventAggregator, _eventBusScope);
-            sut.Begin();
-            sut.Flush();
-            Assert.Equal(1, sut.UpdateTrackingPropertiesCount);
-        }
     }
 }


### PR DESCRIPTION
An aggregate should be considered as modified, when a dependen entity was added, updated or deleted.
The relevant modifiedOn property resides on the AggregateRoot
On each UnitOfWork.Complete we traversed the full change tracker graph multiple times to find the respective aggregate root entity for every dependent entity that was modified. Profiling revealed a high cost for this approach, see #96 

This modification implements a different approach. Since EF Core 2.1 there is a new event on the ChangeTracker: `StateChanged`. It is now used to mark the aggregate root entity as modified, as soon as e dependent entity is marked as modified (or deleted/added)