### PR TITLE
Added InMemoryMessageBusChannel

### DIFF
--- a/src/abstractions/Backend.Fx/Patterns/EventAggregation/Integration/InMemoryMessageBusChannel.cs
+++ b/src/abstractions/Backend.Fx/Patterns/EventAggregation/Integration/InMemoryMessageBusChannel.cs
@@ -1,0 +1,30 @@
+﻿namespace Backend.Fx.Patterns.EventAggregation.Integration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    
+    public class InMemoryMessageBusChannel
+    {
+        private readonly List<Task> _messageHandlingTasks = new List<Task>();
+        
+        internal event EventHandler<MessageReceivedEventArgs> MessageReceived;
+
+        internal void Publish(IIntegrationEvent integrationEvent)
+        {
+            var eventArgs = new MessageReceivedEventArgs { IntegrationEvent = integrationEvent };
+            _messageHandlingTasks.Add(Task.Run(() => MessageReceived?.Invoke(this, eventArgs)));
+        }
+
+        public async Task FinishHandlingAllMessagesAsync()
+        {
+            await Task.WhenAll(_messageHandlingTasks);
+            _messageHandlingTasks.Clear();
+        }
+        
+        internal class MessageReceivedEventArgs
+        {
+            public IIntegrationEvent IntegrationEvent { get; set; }
+        }
+    }
+}

--- a/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/BlockingMessageHandler.cs
+++ b/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/BlockingMessageHandler.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+using System.Threading;
+using Backend.Fx.Patterns.EventAggregation.Integration;
+using Xunit;
+
+namespace Backend.Fx.Tests.Patterns.EventAggregation.Integration
+{
+    public class BlockingMessageHandler : IIntegrationMessageHandler<TestIntegrationEvent>
+    {
+        private readonly ManualResetEvent _manualResetEvent;
+
+        public BlockingMessageHandler(ManualResetEvent manualResetEvent)
+        {
+            _manualResetEvent = manualResetEvent;
+        }
+
+        public void Handle(TestIntegrationEvent eventData)
+        {
+            Assert.True(
+                _manualResetEvent.WaitOne(Debugger.IsAttached ? int.MaxValue : 1000), 
+                "The BlockingMessageHandler was not reset.");
+        }
+    }
+}

--- a/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheInMemoryMessageBusChannel.cs
+++ b/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheInMemoryMessageBusChannel.cs
@@ -1,0 +1,63 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Backend.Fx.Patterns.EventAggregation.Integration;
+using Xunit;
+
+namespace Backend.Fx.Tests.Patterns.EventAggregation.Integration
+{
+    public class TheInMemoryMessageBusChannel
+    {
+        [Fact]
+        public async Task HandlesEventsAsynchronously()
+        {
+            var channel = new InMemoryMessageBusChannel();
+            var messageBus = new InMemoryMessageBus(channel);
+            messageBus.Connect();
+            messageBus.ProvideInvoker(new TheMessageBus.TestInvoker());
+
+            var handled = new ManualResetEvent(false);
+            messageBus.Subscribe(new BlockingMessageHandler(handled));
+
+            await messageBus.Publish(new TestIntegrationEvent(0, string.Empty));
+
+            var finishHandleTask = channel.FinishHandlingAllMessagesAsync();
+            Assert.Contains(finishHandleTask.Status, new[] {TaskStatus.WaitingForActivation, TaskStatus.Running});
+            handled.Set();
+
+            await finishHandleTask;
+        }
+        
+        [Fact]
+        public async Task InvokesAllApplicationHandlers()
+        {
+            var channel = new InMemoryMessageBusChannel();
+            
+            var messageBus = new InMemoryMessageBus(channel);
+            var eventHandled = false;
+            messageBus.Connect();
+            messageBus.ProvideInvoker(new TheMessageBus.TestInvoker());
+            messageBus.Subscribe(new DelegateIntegrationMessageHandler<TestIntegrationEvent>(ev => eventHandled = true));
+            
+            var anotherMessageBus = new InMemoryMessageBus(channel);
+            var anotherEventHandled = false;
+            anotherMessageBus.Connect();
+            anotherMessageBus.ProvideInvoker(new TheMessageBus.TestInvoker());
+            messageBus.Subscribe(new DelegateIntegrationMessageHandler<TestIntegrationEvent>(ev => anotherEventHandled = true));
+
+            await messageBus.Publish(new TestIntegrationEvent(0, string.Empty));
+            await channel.FinishHandlingAllMessagesAsync();
+
+            Assert.True(eventHandled);
+            Assert.True(anotherEventHandled);
+
+            eventHandled = false;
+            anotherEventHandled = false;
+            
+            await anotherMessageBus.Publish(new TestIntegrationEvent(0, string.Empty));
+            await channel.FinishHandlingAllMessagesAsync();
+            
+            Assert.True(eventHandled);
+            Assert.True(anotherEventHandled);
+        }
+    }
+}

--- a/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheMessageBus.cs
+++ b/tests/Backend.Fx.Tests/Patterns/EventAggregation/Integration/TheMessageBus.cs
@@ -17,6 +17,7 @@ namespace Backend.Fx.Tests.Patterns.EventAggregation.Integration
         public TheInMemoryMessageBus()
         {
             Sut.ProvideInvoker(FakeApplication.Invoker);
+            Sut.Connect();
         }
         
         [Fact]


### PR DESCRIPTION
Adding InMemoryMessageBusChannel to process messages in multiple applications.
A InMemoryMessageBus can only be linked to one application. The channel distributes messages accross multiple applications so that each application can get its own message bus instance.

resolves #118 