### PR TITLE
streamlining recent logging changes

### DIFF
--- a/src/abstractions/Backend.Fx/Logging/Log.cs
+++ b/src/abstractions/Backend.Fx/Logging/Log.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Backend.Fx.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Backend.Fx.Logging
@@ -32,23 +33,37 @@ namespace Backend.Fx.Logging
 
         public static Microsoft.Extensions.Logging.ILogger Create<T>()
         {
-            return GetLoggerFactory().CreateLogger(typeof(T).FullName);
+            return LoggerFactory.CreateLogger(typeof(T).FullName);
         }
 
         public static Microsoft.Extensions.Logging.ILogger Create(Type t)
         {
-            return GetLoggerFactory().CreateLogger(t.FullName);
+            return LoggerFactory.CreateLogger(t.FullName);
         }
 
         public static Microsoft.Extensions.Logging.ILogger Create(string category)
         {
-            return GetLoggerFactory().CreateLogger(category);
+            return LoggerFactory.CreateLogger(category);
         }
 
-        private static Microsoft.Extensions.Logging.ILoggerFactory GetLoggerFactory()
+        public static Microsoft.Extensions.Logging.ILoggerFactory LoggerFactory { get; }
+            = new MaybeAsyncLocalLoggerFactory();
+
+        private class MaybeAsyncLocalLoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory
         {
-            return AsyncLocalLoggerFactory.Value ?? _loggerFactory;
+            public void Dispose()
+            {
+            }
+
+            public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+            {
+                return (AsyncLocalLoggerFactory.Value ?? _loggerFactory)
+                    .CreateLogger(categoryName);
+            }
+
+            public void AddProvider(ILoggerProvider provider)
+            {
+            }
         }
     }
-
 }

--- a/tests/Backend.Fx.SimpleInjectorDependencyInjection.Tests/TheSimpleInjectorCompositionRoot.cs
+++ b/tests/Backend.Fx.SimpleInjectorDependencyInjection.Tests/TheSimpleInjectorCompositionRoot.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -11,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Backend.Fx.SimpleInjectorDependencyInjection.Tests
 {
-    public class TheSimpleInjectorCompositionRoot : TestWithLogging, IDisposable
+    public class TheSimpleInjectorCompositionRoot : TestWithLogging
     {
         private readonly SimpleInjectorCompositionRoot _sut;
 
@@ -162,9 +161,10 @@ namespace Backend.Fx.SimpleInjectorDependencyInjection.Tests
             }
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             _sut.Dispose();
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Make the used and maybe async-local LoggerFactory public visible to be used in tests, preliminary