### PR TITLE
Introduced tenant wide mutexes

### DIFF
--- a/src/abstractions/Backend.Fx/Environment/MultiTenancy/ITenantWideMutex.cs
+++ b/src/abstractions/Backend.Fx/Environment/MultiTenancy/ITenantWideMutex.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Backend.Fx.Environment.MultiTenancy
+{
+    public interface ITenantWideMutex : IDisposable
+    { }
+}

--- a/src/abstractions/Backend.Fx/Environment/MultiTenancy/ITenantWideMutexManager.cs
+++ b/src/abstractions/Backend.Fx/Environment/MultiTenancy/ITenantWideMutexManager.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace Backend.Fx.Environment.MultiTenancy
+{
+    public interface ITenantWideMutexManager
+    {
+        bool TryAcquire(TenantId tenantId, string key, out ITenantWideMutex mutex);
+    }
+
+    /// <summary>
+    /// If an instance of this class is being hold as singleton it can be used to manage tenant wide
+    /// mutexes in a single process. When multiple processes are running, another locking mechanism
+    /// must be implemented (e.g. using MS SQL`s <code>sp_getapplock</code> or Postgres` advisory locks)  
+    /// </summary>
+    public class InMemoryTenantWideMutexManager : ITenantWideMutexManager
+    {
+        private readonly ConcurrentDictionary<int, ConcurrentDictionary<string,Mutex>> _mutexes =
+            new ConcurrentDictionary<int, ConcurrentDictionary<string,Mutex>>();
+        
+        public bool TryAcquire(TenantId tenantId, string key, out ITenantWideMutex tenantWideMutex)
+        {
+            if (!tenantId.HasValue)
+            {
+                throw new InvalidOperationException("Cannot acquire a tenant wide lock for tenant NULL");
+            }
+
+            lock (this)
+            {
+                var subDictionary = _mutexes.GetOrAdd(tenantId.Value, i => new ConcurrentDictionary<string, Mutex>());
+                var mutex = subDictionary.GetOrAdd(key, s => new Mutex());
+                if (mutex.WaitOne(300))
+                {
+                    tenantWideMutex = new InMemoryTenantWideMutex(() => mutex.ReleaseMutex());
+                    return true;
+                }
+                else
+                {
+                    tenantWideMutex = null;
+                    return false;
+                }
+            }
+        }
+        
+        private class InMemoryTenantWideMutex  : ITenantWideMutex
+        {
+            private readonly Action _dispose;
+
+            public InMemoryTenantWideMutex([NotNull] Action dispose)
+            {
+                _dispose = dispose ?? throw new ArgumentNullException(nameof(dispose));
+            }
+            
+            public void Dispose()
+            {
+                _dispose.Invoke();
+            }
+        }
+    }
+}

--- a/src/abstractions/Backend.Fx/Patterns/DataGeneration/GenerateDataOnBoot.cs
+++ b/src/abstractions/Backend.Fx/Patterns/DataGeneration/GenerateDataOnBoot.cs
@@ -22,13 +22,14 @@ namespace Backend.Fx.Patterns.DataGeneration
         private readonly ManualResetEventSlim _dataGenerated = new ManualResetEventSlim(false);
         public IDataGenerationContext DataGenerationContext { get; [UsedImplicitly] private set; }
 
-        public GenerateDataOnBoot(ITenantIdProvider tenantIdProvider, IModule dataGenerationModule, IBackendFxApplication application)
+        public GenerateDataOnBoot(ITenantIdProvider tenantIdProvider, IModule dataGenerationModule, IBackendFxApplication application, ITenantWideMutexManager tenantWideMutexManager)
         {
             _tenantIdProvider = tenantIdProvider;
             _application = application;
             _dataGenerationModule = dataGenerationModule;
             DataGenerationContext = new DataGenerationContext(_application.CompositionRoot,
-                                                              _application.Invoker);
+                                                              _application.Invoker,
+                                                              tenantWideMutexManager);
         }
 
         public void Dispose()

--- a/src/abstractions/Backend.Fx/Patterns/DataGeneration/GenerateDataOnTenantCreated.cs
+++ b/src/abstractions/Backend.Fx/Patterns/DataGeneration/GenerateDataOnTenantCreated.cs
@@ -1,25 +1,30 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Backend.Fx.Environment.MultiTenancy;
 using Backend.Fx.Logging;
-using Backend.Fx.Patterns.DataGeneration;
 using Backend.Fx.Patterns.DependencyInjection;
 using Backend.Fx.Patterns.EventAggregation.Integration;
 using Microsoft.Extensions.Logging;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
-namespace Backend.Fx.Environment.MultiTenancy
+namespace Backend.Fx.Patterns.DataGeneration
 {
-    public class MultiTenantApplication : IBackendFxApplication
+    public class GenerateDataOnTenantCreated : IBackendFxApplication
     {
-        private static readonly ILogger Logger = Log.Create<MultiTenantApplication>();
+        private static readonly ILogger Logger = Log.Create<GenerateDataOnTenantCreated>();
         private readonly DataGenerationContext _dataGenerationContext;
         private readonly IBackendFxApplication _application;
 
-        public MultiTenantApplication(IBackendFxApplication application)
+        public GenerateDataOnTenantCreated(
+            IBackendFxApplication application,
+            ITenantWideMutexManager tenantWideMutexManager)
         {
             _application = application;
-            _dataGenerationContext = new DataGenerationContext(_application.CompositionRoot, _application.Invoker);
+            _dataGenerationContext = new DataGenerationContext(
+                _application.CompositionRoot,
+                _application.Invoker,
+                tenantWideMutexManager);
         }
 
         public void Dispose()

--- a/tests/Backend.Fx.AspNetCore.Tests/SampleApp/Runtime/SampleApplication.cs
+++ b/tests/Backend.Fx.AspNetCore.Tests/SampleApp/Runtime/SampleApplication.cs
@@ -17,17 +17,19 @@ namespace Backend.Fx.AspNetCore.Tests.SampleApp.Runtime
 
         public SampleApplication(ITenantIdProvider tenantIdProvider, IExceptionLogger exceptionLogger)
         {
+            ITenantWideMutexManager tenantWideMutexManager = new InMemoryTenantWideMutexManager();
             Assembly domainAssembly = GetType().Assembly;
             
             _application = new BackendFxApplication(
                 new SimpleInjectorCompositionRoot(),
                 new InMemoryMessageBus(),
                 exceptionLogger);
-            _application = new MultiTenantApplication(_application);
+            _application = new GenerateDataOnTenantCreated(_application, tenantWideMutexManager);
             _application = new GenerateDataOnBoot(
                 tenantIdProvider,
                 new SimpleInjectorDataGenerationModule(domainAssembly), 
-                _application);
+                _application,
+                tenantWideMutexManager);
             _application.CompositionRoot.RegisterModules(
                 new SimpleInjectorDomainModule(domainAssembly));
         }

--- a/tests/Backend.Fx.Tests/Environment/MultiTenancy/TheGenerateDataOnTenantCreated.cs
+++ b/tests/Backend.Fx.Tests/Environment/MultiTenancy/TheGenerateDataOnTenantCreated.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using Backend.Fx.Environment.MultiTenancy;
+using Backend.Fx.Patterns.DataGeneration;
 using Backend.Fx.Patterns.DependencyInjection;
 using Backend.Fx.Patterns.EventAggregation.Integration;
 using FakeItEasy;
@@ -8,16 +9,16 @@ using Xunit.Abstractions;
 
 namespace Backend.Fx.Tests.Environment.MultiTenancy
 {
-    public class TheMultiTenantApplication : TestWithLogging
+    public class TheGenerateDataOnTenantCreated : TestWithLogging
     {
         private readonly IBackendFxApplication _sut;
         private readonly IModule _multiTenancyModule = A.Fake<IModule>();
         private readonly ITenantService _tenantService = A.Fake<ITenantService>();
         private readonly IBackendFxApplication _application = A.Fake<IBackendFxApplication>();
 
-        public TheMultiTenantApplication(ITestOutputHelper output): base(output)
+        public TheGenerateDataOnTenantCreated(ITestOutputHelper output): base(output)
         {
-            _sut = new MultiTenantApplication(_application);
+            _sut = new GenerateDataOnTenantCreated(_application, new InMemoryTenantWideMutexManager());
         }
 
         

--- a/tests/Backend.Fx.Tests/Patterns/DataGeneration/TheDataGenerationContext.cs
+++ b/tests/Backend.Fx.Tests/Patterns/DataGeneration/TheDataGenerationContext.cs
@@ -13,28 +13,35 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
 {
     public class TheDataGenerationContext : TestWithLogging
     {
-        public TheDataGenerationContext(ITestOutputHelper output): base(output)
+        private readonly ITenantWideMutexManager _tenantWideMutexManager = A.Fake<ITenantWideMutexManager>();
+
+        public TheDataGenerationContext(ITestOutputHelper output) : base(output)
         {
             var fakes = new DiTestFakes();
-            A.CallTo(() => fakes.InstanceProvider.GetInstances<IDataGenerator>()).Returns(_demoDataGenerators.Concat(_prodDataGenerators.Cast<IDataGenerator>()).ToArray());
+            A.CallTo(() => fakes.InstanceProvider.GetInstances<IDataGenerator>())
+                .Returns(_demoDataGenerators.Concat(_prodDataGenerators.Cast<IDataGenerator>()).ToArray());
 
             var application = A.Fake<IBackendFxApplication>();
             A.CallTo(() => application.Invoker).Returns(fakes.Invoker);
             A.CallTo(() => application.WaitForBoot(A<int>._, A<CancellationToken>._)).Returns(true);
-            
+
             var messageBus = new InMemoryMessageBus();
             messageBus.ProvideInvoker(application.Invoker);
-            
+
             var tenantIdProvider = A.Fake<ITenantIdProvider>();
             A.CallTo(() => tenantIdProvider.GetActiveDemonstrationTenantIds()).Returns(_demoTenants);
             A.CallTo(() => tenantIdProvider.GetActiveProductionTenantIds()).Returns(_prodTenants);
-            
+
             _sut = new DataGenerationContext(fakes.CompositionRoot,
-                                             fakes.Invoker);
+                fakes.Invoker,
+                _tenantWideMutexManager);
         }
 
         private readonly DataGenerationContext _sut;
-        private readonly IDemoDataGenerator[] _demoDataGenerators = {new DemoDataGenerator1(), new DemoDataGenerator2()};
+
+        private readonly IDemoDataGenerator[] _demoDataGenerators =
+            {new DemoDataGenerator1(), new DemoDataGenerator2()};
+
         private readonly IProductiveDataGenerator[] _prodDataGenerators = {new ProdDataGenerator1()};
         private readonly TenantId[] _demoTenants = {new TenantId(1), new TenantId(2)};
         private readonly TenantId[] _prodTenants = {new TenantId(11), new TenantId(12)};
@@ -44,6 +51,18 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
         [InlineData(false)]
         public void CallsDataGeneratorWhenSeedingForSpecificTenant(bool isDemoTenant)
         {
+            ITenantWideMutex disposable = A.Fake<ITenantWideMutex>();
+            ITenantWideMutex m;
+            var tryAcquireCall = A.CallTo(() =>
+                _tenantWideMutexManager.TryAcquire(
+                    A<TenantId>.That.Matches(
+                        t => t.Value == 123),
+                    A<string>.That.Matches(s => s == "DataGenerationContext"),
+                    out m));
+            tryAcquireCall
+                .Returns(true)
+                .AssignsOutAndRefParameters(disposable);
+
             _sut.SeedDataForTenant(new TenantId(123), isDemoTenant);
 
             foreach (IProductiveDataGenerator dataGenerator in _prodDataGenerators)
@@ -54,6 +73,36 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
                     A.CallTo(() => ((DemoDataGenerator) dataGenerator).Impl.Generate()).MustHaveHappenedOnceExactly();
                 else
                     A.CallTo(() => ((DemoDataGenerator) dataGenerator).Impl.Generate()).MustNotHaveHappened();
+
+            tryAcquireCall.MustHaveHappenedOnceExactly();
+            A.CallTo(() => disposable.Dispose()).MustHaveHappenedOnceExactly();
+        }
+        
+        [Fact]
+        public void DoesNothingWhenCannotAcquireTenantWideMutex()
+        {
+            ITenantWideMutex m;
+            var tryAcquireCall = A.CallTo(() =>
+                _tenantWideMutexManager.TryAcquire(
+                    A<TenantId>.That.Matches(
+                        t => t.Value == 123),
+                    A<string>.That.Matches(s => s == "DataGenerationContext"),
+                    out m));
+            tryAcquireCall.Returns(false);
+
+            _sut.SeedDataForTenant(new TenantId(123), false);
+
+            foreach (IProductiveDataGenerator dataGenerator in _prodDataGenerators)
+            {
+                A.CallTo(() => ((ProdDataGenerator) dataGenerator).Impl.Generate()).MustNotHaveHappened();
+            }
+
+            foreach (IDemoDataGenerator dataGenerator in _demoDataGenerators)
+            {
+                A.CallTo(() => ((DemoDataGenerator) dataGenerator).Impl.Generate()).MustNotHaveHappened();
+            }
+
+            tryAcquireCall.MustHaveHappenedOnceExactly();
         }
 
         private abstract class DemoDataGenerator : IDemoDataGenerator

--- a/tests/Backend.Fx.Tests/Patterns/DataGeneration/TheGenerateDataOnBootDecorator.cs
+++ b/tests/Backend.Fx.Tests/Patterns/DataGeneration/TheGenerateDataOnBootDecorator.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using System.Threading.Tasks;
 using Backend.Fx.Environment.MultiTenancy;
 using Backend.Fx.Hacking;
@@ -13,17 +12,21 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
 {
     public class TheGenerateDataOnBootDecorator : TestWithLogging
     {
-        public TheGenerateDataOnBootDecorator(ITestOutputHelper output): base(output)
+        public TheGenerateDataOnBootDecorator(ITestOutputHelper output) : base(output)
         {
+            ITenantWideMutexManager tenantWideMutexManager = new InMemoryTenantWideMutexManager();
             _compositionRoot = A.Fake<ICompositionRoot>();
             _dataGenerationModule = A.Fake<IModule>();
             _dataGenerationContext = A.Fake<IDataGenerationContext>();
             _tenantIdProvider = A.Fake<ITenantIdProvider>();
-            
+
             var backendFxApplication = A.Fake<IBackendFxApplication>();
             A.CallTo(() => backendFxApplication.CompositionRoot).Returns(_compositionRoot);
-            _sut = new GenerateDataOnBoot(_tenantIdProvider,
-                                          _dataGenerationModule, backendFxApplication);
+            _sut = new GenerateDataOnBoot(
+                _tenantIdProvider,
+                _dataGenerationModule,
+                backendFxApplication,
+                tenantWideMutexManager);
 
             _sut.SetPrivate(f => f.DataGenerationContext, _dataGenerationContext);
         }
@@ -38,7 +41,7 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
         public void DelegatesAllOtherCalls()
         {
             var app = A.Fake<IBackendFxApplication>();
-            IBackendFxApplication sut = new GenerateDataOnBoot(A.Fake<ITenantIdProvider>(), A.Fake<IModule>(), app);
+            IBackendFxApplication sut = new GenerateDataOnBoot(A.Fake<ITenantIdProvider>(), A.Fake<IModule>(), app, new InMemoryTenantWideMutexManager());
 
 
             // ReSharper disable UnusedVariable
@@ -64,7 +67,8 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
         public async Task RegistersDataGenerationModuleOnBoot()
         {
             await _sut.BootAsync();
-            A.CallTo(() => _compositionRoot.RegisterModules(A<IModule[]>.That.Contains(_dataGenerationModule))).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _compositionRoot.RegisterModules(A<IModule[]>.That.Contains(_dataGenerationModule)))
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -73,15 +77,23 @@ namespace Backend.Fx.Tests.Patterns.DataGeneration
             var tenantId1 = new TenantId(1);
             var tenantId2 = new TenantId(2);
             var tenantId3 = new TenantId(3);
-            var tenantId4 = new TenantId(4);    
-            
+            var tenantId4 = new TenantId(4);
+
             A.CallTo(() => _tenantIdProvider.GetActiveDemonstrationTenantIds()).Returns(new[] {tenantId1, tenantId2});
             A.CallTo(() => _tenantIdProvider.GetActiveProductionTenantIds()).Returns(new[] {tenantId3, tenantId4});
             await _sut.BootAsync();
-            A.CallTo(() => _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId1), A<bool>.That.IsEqualTo(true))).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId2), A<bool>.That.IsEqualTo(true))).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId3), A<bool>.That.IsEqualTo(false))).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId4), A<bool>.That.IsEqualTo(false))).MustHaveHappenedOnceExactly();
+            A.CallTo(() =>
+                _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId1),
+                    A<bool>.That.IsEqualTo(true))).MustHaveHappenedOnceExactly();
+            A.CallTo(() =>
+                _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId2),
+                    A<bool>.That.IsEqualTo(true))).MustHaveHappenedOnceExactly();
+            A.CallTo(() =>
+                _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId3),
+                    A<bool>.That.IsEqualTo(false))).MustHaveHappenedOnceExactly();
+            A.CallTo(() =>
+                _dataGenerationContext.SeedDataForTenant(A<TenantId>.That.IsEqualTo(tenantId4),
+                    A<bool>.That.IsEqualTo(false))).MustHaveHappenedOnceExactly();
 
             Assert.True(_sut.WaitForBoot(1000));
         }


### PR DESCRIPTION
For single process  applications the `InMemoryTenantWideMutexManager` can be used.

multi process applications should implement mutexing against the database or similar